### PR TITLE
Handle missing Supabase configuration and document setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_SUPABASE_URL="https://your-project.supabase.co"
+VITE_SUPABASE_ANON_KEY="YOUR_ANON_PUBLIC_KEY"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Services Marketplace
+
+Simple marketplace MVP built with React and Vite.
+
+## Environment Variables
+
+This project uses [Supabase](https://supabase.com/) for authentication and data.
+Create a `.env` file with the following variables (you can copy from `.env.example`):
+
+```
+VITE_SUPABASE_URL="https://your-project.supabase.co"
+VITE_SUPABASE_ANON_KEY="YOUR_ANON_PUBLIC_KEY"
+```
+
+Without valid credentials the application will still load but any Supabase
+functionality will be disabled.
+
+## Scripts
+
+- `npm run dev` – start the development server
+- `npm run build` – build the production bundle
+- `npm run preview` – preview the production build
+

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Marketplace MVP</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,7 +1,16 @@
 import { createClient } from "@supabase/supabase-js";
 
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  console.warn(
+    "Supabase credentials are not configured. Using placeholder values; functionality will be limited.",
+  );
+}
+
 export const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL!,
-  import.meta.env.VITE_SUPABASE_ANON_KEY!,
+  supabaseUrl || "https://example.supabase.co",
+  supabaseAnonKey || "public-anon-key",
 );
 


### PR DESCRIPTION
## Summary
- prevent crash when Supabase env vars are absent by warning and using placeholders
- link to existing SVG favicon to avoid missing icon requests
- add `.env.example` and update README with setup instructions

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a4fe5d1e74832a841bc1bcf4201d6c