### PR TITLE
Fail fast when Supabase credentials are missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ VITE_SUPABASE_URL="https://your-project.supabase.co"
 VITE_SUPABASE_ANON_KEY="YOUR_ANON_PUBLIC_KEY"
 ```
 
-Without valid credentials the application will still load but any Supabase
-functionality will be disabled.
+The application requires valid credentials. If they are missing the build
+will throw an error and authentication features such as the magic link login
+will not work.
 
 ## Scripts
 

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,16 +1,17 @@
 import { createClient } from "@supabase/supabase-js";
 
+// Supabase credentials are provided via Vite environment variables.
+// Throw early if they are missing so the application fails fast with a
+// clear message instead of attempting to contact a non-existent project
+// (which would surface as a generic "Failed to fetch" error at runtime).
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 if (!supabaseUrl || !supabaseAnonKey) {
-  console.warn(
-    "Supabase credentials are not configured. Using placeholder values; functionality will be limited.",
+  throw new Error(
+    "Supabase credentials are not configured. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY in your environment.",
   );
 }
 
-export const supabase = createClient(
-  supabaseUrl || "https://example.supabase.co",
-  supabaseAnonKey || "public-anon-key",
-);
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);
 


### PR DESCRIPTION
## Summary
- Stop using placeholder Supabase credentials and throw a clear error when environment variables are missing
- Update README to note that missing credentials will stop the build and disable authentication

## Testing
- `npm test` *(fails: Missing script: "test")*
- `VITE_SUPABASE_URL=http://localhost VITE_SUPABASE_ANON_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a500f902b4832a818621ac083fe084