### PR TITLE
Use category dropdowns for quotes and provider search

### DIFF
--- a/src/pages/NewQuote.tsx
+++ b/src/pages/NewQuote.tsx
@@ -10,10 +10,15 @@ const [uf,setUf]=useState("");
 const [times,setTimes]=useState(""); // CSV of ISO datetimes
 const [budget,setBudget]=useState<number|"">("");
 const [msg,setMsg]=useState("");
+const [categories,setCategories]=useState<{ slug:string; name:string }[]>([]);
 
 useEffect(()=>{(async()=>{
-const { data:{ user } } = await supabase.auth.getUser();
+const [{ data:{ user } }, catRes] = await Promise.all([
+supabase.auth.getUser(),
+supabase.from("categories").select("slug, name")
+]);
 if(user) setUid(user.id);
+setCategories(catRes.data||[]);
 })()},[]);
 
 const submit=async(e:React.FormEvent)=>{
@@ -42,7 +47,12 @@ return (
     <div className="max-w-xl mx-auto mt-6 p-4 border border-gray-200 rounded-lg">
     <h2 className="text-xl font-semibold">Novo Pedido de Orçamento</h2>
     <form onSubmit={submit} className="grid gap-2 mt-4">
-    <input className="p-2 border border-gray-300 rounded" placeholder="category_slug" value={category} onChange={e=>setCategory(e.target.value)} required/>
+    <select className="p-2 border border-gray-300 rounded" value={category} onChange={e=>setCategory(e.target.value)} required>
+    <option value="">Selecione uma categoria</option>
+    {categories.map(c=>(
+      <option key={c.slug} value={c.slug}>{c.name || c.slug}</option>
+    ))}
+    </select>
     <textarea className="p-2 border border-gray-300 rounded" placeholder="Descrição" value={description} onChange={e=>setDescription(e.target.value)} required rows={4}/>
     <div className="grid grid-cols-[1fr_100px] gap-2">
     <input className="p-2 border border-gray-300 rounded" placeholder="Cidade" value={city} onChange={e=>setCity(e.target.value)} required/>

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { supabase } from "../lib/supabase";
 
 type ProviderRow = {
@@ -14,6 +14,12 @@ const [radiusKm,setRadiusKm]=useState<number|"">("");
 const [loading,setLoading]=useState(false);
 const [results,setResults]=useState<ProviderRow[]>([]);
 const [err,setErr]=useState("");
+const [categories,setCategories]=useState<{ slug:string; name:string }[]>([]);
+
+useEffect(()=>{(async()=>{
+const { data } = await supabase.from("categories").select("slug, name");
+setCategories(data||[]);
+})()},[]);
 
 const run = async ()=>{
 setLoading(true); setErr("");
@@ -38,7 +44,12 @@ return (
     <div className="max-w-3xl mx-auto mt-6 p-4">
     <h2 className="text-xl font-semibold">Buscar Prestadores</h2>
     <div className="grid grid-cols-[1fr_1fr_1fr_auto] gap-2 items-center mt-4">
-    <input className="p-2 border border-gray-300 rounded" placeholder="category_slug" value={category} onChange={e=>setCategory(e.target.value)}/>
+    <select className="p-2 border border-gray-300 rounded" value={category} onChange={e=>setCategory(e.target.value)}>
+    <option value="">Todas as categorias</option>
+    {categories.map(c=>(
+      <option key={c.slug} value={c.slug}>{c.name || c.slug}</option>
+    ))}
+    </select>
     <input className="p-2 border border-gray-300 rounded" placeholder="city" value={city} onChange={e=>setCity(e.target.value)}/>
     <input className="p-2 border border-gray-300 rounded" type="number" placeholder="radius_km (ignorado)" value={radiusKm} onChange={e=>setRadiusKm(e.target.value?Number(e.target.value):"")}/>
     <button onClick={run} disabled={loading} className="px-3 py-2 bg-blue-600 text-white rounded disabled:opacity-50">{loading?"Buscando...":"Buscar"}</button>


### PR DESCRIPTION
## Summary
- Replace free-text category field with dropdown in new quote form
- Populate provider search category filter from categories table and use dropdown

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a598f57c34832aa3ac0e1050a8703f