### PR TITLE
feat: separate provider and client roles

### DIFF
--- a/supabase/sql/quotes.sql
+++ b/supabase/sql/quotes.sql
@@ -1,7 +1,7 @@
 -- quote_requests table
 create table if not exists public.quote_requests (
 id uuid primary key default gen_random_uuid(),
-user_id uuid not null,
+user_id uuid not null references public.users(id) on delete cascade,
 category_slug text not null,
 description text not null,
 city text not null,

--- a/supabase/sql/users.sql
+++ b/supabase/sql/users.sql
@@ -1,0 +1,24 @@
+-- users table for regular clients
+create table if not exists public.users (
+  id uuid primary key references auth.users(id) on delete cascade,
+  created_at timestamptz not null default now()
+);
+
+alter table public.users enable row level security;
+
+create policy "users_select_self"
+  on public.users for select
+  using (auth.uid() = id);
+
+create policy "users_insert_self"
+  on public.users for insert
+  with check (auth.uid() = id);
+
+create policy "users_update_self"
+  on public.users for update
+  using (auth.uid() = id)
+  with check (auth.uid() = id);
+
+create policy "users_delete_self"
+  on public.users for delete
+  using (auth.uid() = id);


### PR DESCRIPTION
## Summary
- show different navigation links for providers and regular users
- restrict provider-only and user-only routes
- add Supabase schema for `users` table and link quote requests

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a59cc9f9ac832abd811141996f3480