### PR TITLE
feat: add role-based access

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,13 @@
+export type UserRole = "user" | "provider";
+
+import { supabase } from "./supabase";
+
+export const getUserRole = async (userId: string): Promise<UserRole> => {
+  const { data } = await supabase
+    .from("providers")
+    .select("id")
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  return data ? "provider" : "user";
+};


### PR DESCRIPTION
## Summary
- add reusable `getUserRole` helper
- gate navigation and routes by user role

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5b53cc6b8832a89b21594cf5d2278