### PR TITLE
Require service area when saving provider

### DIFF
--- a/src/pages/ProviderProfile.tsx
+++ b/src/pages/ProviderProfile.tsx
@@ -68,7 +68,11 @@ export default function ProviderProfile() {
   }, []);
 
   const disabled = useMemo(
-    () => !prov.display_name || !prov.city || !prov.uf,
+    () =>
+      !prov.display_name ||
+      !prov.city ||
+      !prov.uf ||
+      prov.service_area_km === null,
     [prov]
   );
 
@@ -154,6 +158,8 @@ export default function ProviderProfile() {
                 service_area_km: e.target.value ? Number(e.target.value) : null,
               }))
             }
+            required
+            min={0}
             className="p-2 border border-gray-300 rounded"
           />
         </div>


### PR DESCRIPTION
## Summary
- prevent submitting provider profile without a service area
- mark service area input as required and restrict to non-negative values

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5cf3d3ef0832ab1b7f80fcf6a7297